### PR TITLE
Centered report popup

### DIFF
--- a/Website/new.html
+++ b/Website/new.html
@@ -297,7 +297,7 @@
   
   
 
-  <div id="popup-report" class="popup-container">
+  <div id="popup-report" class="popup-report-container">
     <div class="popup">
       <div class="popup-header">
          <span class="popup-close" onclick="closePopup('Report')">&times;</span>

--- a/Website/styles/MunchiMaps_stylesheet.css
+++ b/Website/styles/MunchiMaps_stylesheet.css
@@ -674,7 +674,7 @@ html, body {
 }
 
 /*report button*/
-.popup-container {
+.popup-report-container {
   display: none;
   position: fixed;
   top: 0;
@@ -683,6 +683,8 @@ html, body {
   height: 100%;
   background: rgba(0, 0, 0, 0.5);
   z-index: 1000;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.5); /* Window drop shadow */
+  animation: fadeIn 0.5s ease forwards; /* Fade in animation */
 }
 
 .popup {
@@ -723,7 +725,7 @@ html, body {
 
 /* Styles for the dropdown menu in the report form */
 .popup-form select.form-control {
-  width: 100%;
+  width: 50%;
   padding: 8px;
   box-sizing: border-box;
   border: 1px solid #ccc;


### PR DESCRIPTION
Modified HTML and CSS such that the report window pops up in the middle of the screen, rather than being mostly off-screen. Still needs to be further styled to match overall theme.

<img width="1917" height="867" alt="image" src="https://github.com/user-attachments/assets/cc0008fc-c059-4391-b189-89a0ff1d348d" />
