### PR TITLE
Updated JS in new.html

### DIFF
--- a/Website/new.html
+++ b/Website/new.html
@@ -340,6 +340,9 @@
       console.log("Report Description: ", description);
       
       closePopup('Report');
+
+      document.getElementById('reportTitle').value = '';
+      document.getElementById('reportDescription').value = '';
     });
 
   </script>


### PR DESCRIPTION
Previously, even after a report was submitted, the old report title and description would still appear if the user clicked the report button again. Now, after submission, those fields are empty when the pop-up is reopened.